### PR TITLE
Improve logging

### DIFF
--- a/src/indexing/btree.cpp
+++ b/src/indexing/btree.cpp
@@ -595,8 +595,8 @@ namespace embrace::indexing {
             return core::Status::InvalidArgument("Snapshotter not initialized");
         }
 
-        const auto checkpoint_start = std::chrono::steady_clock::now();
         LOG_INFO("Creating checkpoint at operation {} for WAL '{}'", operation_count_, wal_path_);
+        const auto checkpoint_start = std::chrono::steady_clock::now();
 
         auto status = snapshotter_->create_snapshot(*this);
         if (!status.ok()) {

--- a/src/indexing/btree.cpp
+++ b/src/indexing/btree.cpp
@@ -482,7 +482,6 @@ namespace embrace::indexing {
 
         if (snapshotter_ and snapshotter_->exists()) {
             LOG_INFO("Starting recovery: loading snapshot then replaying WAL '{}'", wal_path_);
-            LOG_INFO("Loading snapshot before WAL replay");
             auto status = snapshotter_->load_snapshot(*this);
             if (!status.ok()) {
                 LOG_ERROR("Snapshot load failed: {}", status.to_string());
@@ -553,10 +552,9 @@ namespace embrace::indexing {
             }
         }
 
-        const auto elapsed_ms =
-            std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() -
-                                                                  recovery_start)
-                .count();
+        const auto elapsed_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+                                    std::chrono::steady_clock::now() - recovery_start)
+                                    .count();
 
         LOG_INFO("WAL recovery complete: path='{}', records_replayed={}, elapsed_ms={}", wal_path_,
                  records_recovered, elapsed_ms);

--- a/src/log/logger.cpp
+++ b/src/log/logger.cpp
@@ -31,7 +31,7 @@ namespace embrace::log {
 
     void Logger::init(const LogConfig &config) {
         if (impl_) {
-            LOG_WARN("Logger already initialized, ignoring duplicate init() call");
+            LOG_WARN("Logger already initialized; duplicate init() ignored");
             return; // Already initialized
         }
         config_ = config;

--- a/src/log/logger.hpp
+++ b/src/log/logger.hpp
@@ -77,6 +77,14 @@ namespace embrace::log {
     };
 } // namespace embrace::log
 
+// Logging level guidance (default Level::Info in production)
+// - Trace: extremely verbose internals (per-record/per-node); usually off.
+// - Debug: diagnostics and timings safe to disable in production.
+// - Info: lifecycle milestones (startup, recovery, checkpoints) and success summaries.
+// - Warn: unexpected but tolerated conditions; action may be required.
+// - Error: operation failed; durability or availability likely impacted.
+// - Fatal: process cannot continue; expect termination/abort.
+
 #define LOG_TRACE(...)                                                                             \
     do {                                                                                           \
         auto &logger = ::embrace::log::Logger::instance();                                         \

--- a/src/storage/wal.cpp
+++ b/src/storage/wal.cpp
@@ -137,12 +137,17 @@ namespace embrace::storage {
         const size_t pending_bytes = buffer_.size();
         const auto flush_start = std::chrono::steady_clock::now();
         auto status = flush_buffer();
-        if (status.ok() && pending_bytes > 0) {
+        if (pending_bytes > 0) {
             const auto elapsed_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
                                         std::chrono::steady_clock::now() - flush_start)
                                         .count();
-            LOG_DEBUG("WAL flush completed: path='{}', bytes={}, elapsed_ms={}", wal_path_,
-                      pending_bytes, elapsed_ms);
+            if (status.ok()) {
+                LOG_DEBUG("WAL flush completed: path='{}', bytes={}, elapsed_ms={}", wal_path_,
+                          pending_bytes, elapsed_ms);
+            } else {
+                LOG_ERROR("WAL flush failed: path='{}', bytes={}, elapsed_ms={}, error='{}'", wal_path_,
+                          pending_bytes, elapsed_ms, status.ToString());
+            }
         }
         return status;
     }


### PR DESCRIPTION
This pull request improves logging clarity and adds timing metrics for key durability operations in the B-tree, WAL, and snapshot subsystems. The changes enhance diagnostics by including operation durations and more descriptive log messages, making it easier to monitor and troubleshoot persistence and recovery processes.

**Logging improvements and diagnostics:**

* Added operation timing metrics (elapsed milliseconds) to log messages for WAL recovery, checkpoint creation, WAL flush/sync, and snapshot creation/loading. This helps track performance of durability operations. (`src/indexing/btree.cpp` [[1]](diffhunk://#diff-6402c0cb876a12c59d408c89fa6144d9dc7a7bd2bdc7d61ddb2a2a51b258e3b8R466-R472) [[2]](diffhunk://#diff-6402c0cb876a12c59d408c89fa6144d9dc7a7bd2bdc7d61ddb2a2a51b258e3b8L581-R601) [[3]](diffhunk://#diff-6402c0cb876a12c59d408c89fa6144d9dc7a7bd2bdc7d61ddb2a2a51b258e3b8L612-R636); `src/storage/snapshot.cpp` [[4]](diffhunk://#diff-28e5eb854162466dd147f6f5dfd164b7093181828ec171604c3ceb799283e5fbR93) [[5]](diffhunk://#diff-28e5eb854162466dd147f6f5dfd164b7093181828ec171604c3ceb799283e5fbL178-R185) [[6]](diffhunk://#diff-28e5eb854162466dd147f6f5dfd164b7093181828ec171604c3ceb799283e5fbR212-R216) [[7]](diffhunk://#diff-28e5eb854162466dd147f6f5dfd164b7093181828ec171604c3ceb799283e5fbL282-R296); `src/storage/wal.cpp` [[8]](diffhunk://#diff-1c919241471751125b26308cfe84955ac4d9d97101de232bce33883e714d651bL136-R151) [[9]](diffhunk://#diff-1c919241471751125b26308cfe84955ac4d9d97101de232bce33883e714d651bR164-R168)
* Improved log message clarity and consistency for WAL and snapshot lifecycle events (open/close, recovery start/complete, checkpoint, flush, sync) by including file paths, counts, and descriptive context. (`src/indexing/btree.cpp` [[1]](diffhunk://#diff-6402c0cb876a12c59d408c89fa6144d9dc7a7bd2bdc7d61ddb2a2a51b258e3b8L28-R29) [[2]](diffhunk://#diff-6402c0cb876a12c59d408c89fa6144d9dc7a7bd2bdc7d61ddb2a2a51b258e3b8R466-R472) [[3]](diffhunk://#diff-6402c0cb876a12c59d408c89fa6144d9dc7a7bd2bdc7d61ddb2a2a51b258e3b8L480-R485) [[4]](diffhunk://#diff-6402c0cb876a12c59d408c89fa6144d9dc7a7bd2bdc7d61ddb2a2a51b258e3b8R502-R506) [[5]](diffhunk://#diff-6402c0cb876a12c59d408c89fa6144d9dc7a7bd2bdc7d61ddb2a2a51b258e3b8R525-R532) [[6]](diffhunk://#diff-6402c0cb876a12c59d408c89fa6144d9dc7a7bd2bdc7d61ddb2a2a51b258e3b8R548-R562); `src/storage/wal.cpp` [[7]](diffhunk://#diff-1c919241471751125b26308cfe84955ac4d9d97101de232bce33883e714d651bL22-R25) [[8]](diffhunk://#diff-1c919241471751125b26308cfe84955ac4d9d97101de232bce33883e714d651bL33-R34) [[9]](diffhunk://#diff-1c919241471751125b26308cfe84955ac4d9d97101de232bce33883e714d651bL162-R181); `src/storage/snapshot.cpp` [[10]](diffhunk://#diff-28e5eb854162466dd147f6f5dfd164b7093181828ec171604c3ceb799283e5fbL178-R185) [[11]](diffhunk://#diff-28e5eb854162466dd147f6f5dfd164b7093181828ec171604c3ceb799283e5fbL282-R296)

**Logging level guidance:**

* Added detailed comments explaining the intended use of each logging level (Trace, Debug, Info, Warn, Error, Fatal) to guide future log statements. (`src/log/logger.hpp` [src/log/logger.hppR80-R87](diffhunk://#diff-d5ff46ca400baa5560156509624010241ef23b07ed0a4f474e214a4a567e01abR80-R87))

**Minor changes and cleanup:**

* Improved wording in warning messages for duplicate logger initialization and WAL writer open failures. (`src/log/logger.cpp` [[1]](diffhunk://#diff-e7015285ed88a0fb6a8bdc28e7c5f61ff3d031a220f686b14bba222337d88a16L34-R34); `src/indexing/btree.cpp` [[2]](diffhunk://#diff-6402c0cb876a12c59d408c89fa6144d9dc7a7bd2bdc7d61ddb2a2a51b258e3b8L28-R29)
* Changed checkpoint marker recovery log from Info to Debug to reduce log noise during WAL replay. (`src/indexing/btree.cpp` [src/indexing/btree.cppR548-R562](diffhunk://#diff-6402c0cb876a12c59d408c89fa6144d9dc7a7bd2bdc7d61ddb2a2a51b258e3b8R548-R562))

Let me know if you'd like to discuss how these changes affect debugging or monitoring in production!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added logging level guidance for developers; clarified logger init message wording.

* **Improvements**
  * Enhanced observability: richer, standardized logs for WAL, recovery, checkpoints, and snapshots with timestamps, elapsed-time metrics, progress updates, and clearer open/close/replay messages.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->